### PR TITLE
将默认配置文件中拼写错误修正，secert->secret

### DIFF
--- a/src/config_tool.rs
+++ b/src/config_tool.rs
@@ -42,7 +42,7 @@ pub async fn read_config() -> Result<serde_json::Value, Box<dyn std::error::Erro
         }
     }
     if !is_file_exists{
-        tokio::fs::write(config_file_dir.clone(), "{\"web_port\":8080,\"kook_token\":\"\",\"access_token\":\"\",\"web_host\":\"127.0.0.1\",\"reverse_uri\":[],\"secert\":\"\"}").await?;
+        tokio::fs::write(config_file_dir.clone(), "{\"web_port\":8080,\"kook_token\":\"\",\"access_token\":\"\",\"web_host\":\"127.0.0.1\",\"reverse_uri\":[],\"secret\":\"\"}").await?;
         log::error!("config.json文件不存在，为您自动生成！请自行修改后重新运行！！！");
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;


### PR DESCRIPTION
大佬看看这么改对不对，我没有自己编译跑一遍，但是改了配置文件就可以避免'配置文件缺少 secret 字段'报错了